### PR TITLE
Property support

### DIFF
--- a/ThreadSafeObject/.editorconfig
+++ b/ThreadSafeObject/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+end_of_line = crlf
+
+[*.xml]
+indent_style = space

--- a/ThreadSafeObject/TestNet45/Program.cs
+++ b/ThreadSafeObject/TestNet45/Program.cs
@@ -24,6 +24,10 @@ namespace TestNet45
             tasks.ForEach(t => t.Start());
             Task.WaitAll(tasks.ToArray());
             Console.WriteLine($"task iterations {nrIterations} result: {c.i}");
+
+            Console.WriteLine($"Field access: {ts.i}");
+            Console.WriteLine($"Property access: {ts.Value}");
+            Console.WriteLine($"Indexer access: {ts["key"]}");
         }
     }
 }

--- a/ThreadSafeObject/TestNet45/TestNet45.csproj
+++ b/ThreadSafeObject/TestNet45/TestNet45.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestObject\TestObject.csproj">

--- a/ThreadSafeObject/TestNet45/packages.config
+++ b/ThreadSafeObject/TestNet45/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
+</packages>

--- a/ThreadSafeObject/TestNetCore/Program.cs
+++ b/ThreadSafeObject/TestNetCore/Program.cs
@@ -8,7 +8,7 @@ namespace TestNetCore
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             int nrIterations = 100000;
             Calculation c = new Calculation();
@@ -22,6 +22,10 @@ namespace TestNetCore
             tasks.ForEach(t => t.Start());
             Task.WaitAll(tasks.ToArray());
             Console.WriteLine($"task iterations {nrIterations} result: {c.i}");
+
+            Console.WriteLine($"Field access: {ts.i}");
+            Console.WriteLine($"Property access: {ts.Value}");
+            Console.WriteLine($"Indexer access: {ts["key"]}");
         }
     }
 }

--- a/ThreadSafeObject/TestObject/Calculation.cs
+++ b/ThreadSafeObject/TestObject/Calculation.cs
@@ -9,21 +9,37 @@ namespace TestObject
     public class Calculation
     {
         public int i;
+
+        public int Value
+        {
+            get { return i; }
+            set { i = value; }
+        }
+
+        public int this[string key]
+        {
+            get { return i; }
+            set { i = value; }
+        }
+
         public int Add()
         {
             i++;
             return i;
         }
+
         public int Operation(int j)
         {
             i += j;
             return i;
         }
+
         public int Decrease()
         {
             i--;
             return i;
         }
+
         public int TwoOperations()
         {
             Add();

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationField.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationField.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestObject;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ThreadSafeObject;
+
+namespace TestThreadSafe
+{
+	[TestClass]
+	public class TestCalculationField
+	{
+		[TestMethod]
+		public void NotThreadSafeProperty()
+		{
+			int nrIterations = 100000;
+			Calculation c = new Calculation();
+			List<Task> tasks = new List<Task>();
+			for (int i = 0; i < nrIterations; i++)
+			{
+				var t = new Task<int>(() => c.i++);
+				tasks.Add(t);
+			}
+			tasks.ForEach(t => t.Start());
+			Task.WaitAll(tasks.ToArray());
+			Console.WriteLine("Result not thread safe" + c.i);
+			Assert.AreNotEqual(nrIterations, c.i);
+		}
+		[TestMethod]
+		public void ThreadSafePropertyNotWorking()
+		{
+			int nrIterations = 100000;
+			Calculation c = new Calculation();
+			dynamic ts = new ThreadSafe(c);
+			List<Task> tasks = new List<Task>();
+			for (int i = 0; i < nrIterations; i++)
+			{
+				var t = new Task<int>(() => ts.i++);
+				tasks.Add(t);
+			}
+			tasks.ForEach(t => t.Start());
+			Task.WaitAll(tasks.ToArray());
+			Assert.AreNotEqual(nrIterations, c.i);
+		}
+	}
+}

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationField.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationField.cs
@@ -11,7 +11,7 @@ namespace TestThreadSafe
 	public class TestCalculationField
 	{
 		[TestMethod]
-		public void NotThreadSafeProperty()
+		public void NotThreadSafeField()
 		{
 			int nrIterations = 100000;
 			Calculation c = new Calculation();
@@ -27,7 +27,7 @@ namespace TestThreadSafe
 			Assert.AreNotEqual(nrIterations, c.i);
 		}
 		[TestMethod]
-		public void ThreadSafePropertyNotWorking()
+		public void ThreadSafeField()
 		{
 			int nrIterations = 100000;
 			Calculation c = new Calculation();

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationIndexer.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationIndexer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestObject;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ThreadSafeObject;
+
+namespace TestThreadSafe
+{
+	[TestClass]
+	public class TestCalculationIndexer
+	{
+		[TestMethod]
+		public void NotThreadSafeProperty()
+		{
+			int nrIterations = 100000;
+			Calculation c = new Calculation();
+			List<Task> tasks = new List<Task>();
+			for (int i = 0; i < nrIterations; i++)
+			{
+				var t = new Task<int>(() => c["key"]++);
+				tasks.Add(t);
+			}
+			tasks.ForEach(t => t.Start());
+			Task.WaitAll(tasks.ToArray());
+			Console.WriteLine("Result not thread safe" + c["key"]);
+			Assert.AreNotEqual(nrIterations, c["key"]);
+		}
+		[TestMethod]
+		public void ThreadSafePropertyNotWorking()
+		{
+			int nrIterations = 100000;
+			Calculation c = new Calculation();
+			dynamic ts = new ThreadSafe(c);
+			List<Task> tasks = new List<Task>();
+			for (int i = 0; i < nrIterations; i++)
+			{
+				var t = new Task<int>(() => ts["key"]++);
+				tasks.Add(t);
+			}
+			tasks.ForEach(t => t.Start());
+			Task.WaitAll(tasks.ToArray());
+			Assert.AreNotEqual(nrIterations, c["key"]);
+		}
+	}
+}

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationIndexer.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationIndexer.cs
@@ -11,7 +11,7 @@ namespace TestThreadSafe
 	public class TestCalculationIndexer
 	{
 		[TestMethod]
-		public void NotThreadSafeProperty()
+		public void NotThreadSafeIndexer()
 		{
 			int nrIterations = 100000;
 			Calculation c = new Calculation();
@@ -27,7 +27,7 @@ namespace TestThreadSafe
 			Assert.AreNotEqual(nrIterations, c["key"]);
 		}
 		[TestMethod]
-		public void ThreadSafePropertyNotWorking()
+		public void ThreadSafeIndexer()
 		{
 			int nrIterations = 100000;
 			Calculation c = new Calculation();

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationProperty.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationProperty.cs
@@ -18,13 +18,13 @@ namespace TestThreadSafe
             List<Task> tasks = new List<Task>();
             for (int i = 0; i < nrIterations; i++)
             {
-                var t = new Task<int>(() => c.i++);
+                var t = new Task<int>(() => c.Value++);
                 tasks.Add(t);
             }
             tasks.ForEach(t => t.Start());
             Task.WaitAll(tasks.ToArray());
-            Console.WriteLine("Result not thread safe" + c.i);
-            Assert.AreNotEqual(nrIterations, c.i);
+            Console.WriteLine("Result not thread safe" + c.Value);
+            Assert.AreNotEqual(nrIterations, c.Value);
         }
         [TestMethod]
         public void ThreadSafePropertyNotWorking()
@@ -35,12 +35,12 @@ namespace TestThreadSafe
             List<Task> tasks = new List<Task>();
             for (int i = 0; i < nrIterations; i++)
             {
-                var t = new Task<int>(() => ts.i++);
+                var t = new Task<int>(() => ts.Value++);
                 tasks.Add(t);
             }
             tasks.ForEach(t => t.Start());
             Task.WaitAll(tasks.ToArray());
-            Assert.AreNotEqual(nrIterations, c.i);
+            Assert.AreNotEqual(nrIterations, c.Value);
         }
     }
 }

--- a/ThreadSafeObject/TestThreadSafe/TestCalculationProperty.cs
+++ b/ThreadSafeObject/TestThreadSafe/TestCalculationProperty.cs
@@ -27,7 +27,7 @@ namespace TestThreadSafe
             Assert.AreNotEqual(nrIterations, c.Value);
         }
         [TestMethod]
-        public void ThreadSafePropertyNotWorking()
+        public void ThreadSafeProperty()
         {
             int nrIterations = 100000;
             Calculation c = new Calculation();

--- a/ThreadSafeObject/TestThreadSafe/TestThreadSafe.csproj
+++ b/ThreadSafeObject/TestThreadSafe/TestThreadSafe.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,10 +41,10 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\NuGetPackages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\NuGetPackages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -52,11 +53,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCalculationAdd.cs" />
     <Compile Include="TestCalculationAddDecrease.cs" />
+    <Compile Include="TestCalculationField.cs" />
+    <Compile Include="TestCalculationIndexer.cs" />
     <Compile Include="TestCalculationProperty.cs" />
     <Compile Include="TestCalculationOperation.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestObject\TestObject.csproj">
@@ -68,6 +68,9 @@
       <Name>ThreadSafeObject</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -76,6 +79,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/ThreadSafeObject/TestThreadSafe/TestThreadSafe.csproj
+++ b/ThreadSafeObject/TestThreadSafe/TestThreadSafe.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,10 +40,10 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\NuGetPackages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\NuGetPackages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -79,9 +78,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
-  <Import Project="..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\..\..\..\NuGetPackages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/ThreadSafeObject/ThreadSafeObject.sln
+++ b/ThreadSafeObject/ThreadSafeObject.sln
@@ -1,17 +1,22 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestThreadSafe", "TestThreadSafe\TestThreadSafe.csproj", "{B5ED6243-089C-4CAB-B512-8F7291D8C885}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThreadSafeObject", "ThreadSafeObject\ThreadSafeObject.csproj", "{063B19C1-956C-45E3-8091-0140C987D93F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThreadSafeObject", "ThreadSafeObject\ThreadSafeObject.csproj", "{063B19C1-956C-45E3-8091-0140C987D93F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestObject", "TestObject\TestObject.csproj", "{98E483C7-1434-46D3-8D6F-0CC72FEC8F54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestObject", "TestObject\TestObject.csproj", "{98E483C7-1434-46D3-8D6F-0CC72FEC8F54}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNet45", "TestNet45\TestNet45.csproj", "{E2CB9B76-1BDE-4EE4-9BEF-454119BD335D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNetCore", "TestNetCore\TestNetCore.csproj", "{0F839E70-2D4D-44CA-9BBB-2DCEDE6AC01F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestNetCore", "TestNetCore\TestNetCore.csproj", "{0F839E70-2D4D-44CA-9BBB-2DCEDE6AC01F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1212EF97-3031-45A8-A6E0-BECDF0BCA215}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ThreadSafeObject/ThreadSafeObject/ThreadSafe.cs
+++ b/ThreadSafeObject/ThreadSafeObject/ThreadSafe.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ThreadSafeObject
 {
@@ -16,74 +12,153 @@ namespace ThreadSafeObject
     /// Means .NET Framework>=1.0
     /// Test and details at https://github.com/ignatandrei/ThreadSafeObject
     /// </summary>
-    public class ThreadSafe: DynamicObject,IDynamicMetaObjectProvider
+    public class ThreadSafe: DynamicObject
     {
-        private object o;
-        TypeInfo t;
-        object myLock;
+        private readonly object o;
+        private readonly TypeInfo t;
+        private readonly object myLock;
+
         /// <summary>
-        /// constructor
-        /// pass the object that you want to make
-        /// functions thread safe
+        /// Initializes a new instance of the <see cref="ThreadSafe"/> class.
         /// </summary>
-        /// <param name="o"></param>
+        /// <param name="o">
+        /// The wrapped object whose operations will be made thread-safe.
+        /// </param>
         public ThreadSafe(object o)
         {
             this.o = o;
             t = o.GetType().GetTypeInfo();
             myLock = new object();
         }
-        /// <summary>
-        /// redirects to original object
-        /// </summary>
-        /// <param name="binder"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
+
+        /// <inheritdoc />
         public override bool TrySetMember(SetMemberBinder binder, object value)
         {
-           
-            var field = t.GetDeclaredField(binder.Name);
-
-            lock (myLock)
+            var prop = t.GetDeclaredProperty(binder.Name);
+            if (prop != null)
             {
-                field.SetValue(o, value);
+                lock (myLock)
+                {
+                    prop.SetValue(o, value);
+                }
+
+                return true;
             }
-            return true;
+
+            var field = t.GetDeclaredField(binder.Name);
+            if (field != null)
+            {
+                lock (myLock)
+                {
+                    field.SetValue(o, value);
+                }
+
+                return true;
+            }
+
+            return false;
         }
-        /// <summary>
-        /// redirect to original object
-        /// </summary>
-        /// <param name="binder"></param>
-        /// <param name="result"></param>
-        /// <returns></returns>
+
+        /// <inheritdoc />
         public override bool TryGetMember(GetMemberBinder binder, out object result)
         {
-            
-            var field = t.GetDeclaredField(binder.Name);
-            
-            lock (myLock)
+            var prop = t.GetDeclaredProperty(binder.Name);
+            if (prop != null)
             {
-                result = field.GetValue(o);
+                lock (myLock)
+                {
+                    result = prop.GetValue(o);
+                }
+
+                return true;
             }
-            return true;
+
+            var field = t.GetDeclaredField(binder.Name);
+            if (field != null)
+            {
+                lock (myLock)
+                {
+                    result = field.GetValue(o);
+                }
+
+                return true;
+            }
+
+            result = null;
+            return false;
         }
+
         /// <summary>
-        /// redirects to original object
+        /// Attempts to find the indexer property.
         /// </summary>
-        /// <param name="binder"></param>
-        /// <param name="args"></param>
-        /// <param name="result"></param>
-        /// <returns></returns>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> for the indexer property, if found;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        private PropertyInfo GetIndexedProperty()
+        {
+            // TODO: Is there a better way to do this?
+
+            var prop = t.GetDeclaredProperty("Item");
+            if (prop == null || prop.GetIndexParameters().Length == 0)
+            {
+                prop = t.DeclaredProperties.FirstOrDefault(p => p.GetIndexParameters().Length != 0);
+            }
+
+            return prop;
+        }
+
+        /// <inheritdoc />
+        public override bool TrySetIndex(SetIndexBinder binder, object[] indexes, object value)
+        {
+            var prop = GetIndexedProperty();
+            if (prop != null)
+            {
+                lock (myLock)
+                {
+                    prop.SetValue(o, value, indexes);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            var prop = GetIndexedProperty();
+            if (prop != null)
+            {
+                lock (myLock)
+                {
+                    result = prop.GetValue(o, indexes);
+                }
+
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        /// <inheritdoc />
         public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
         {
             var method = t.GetDeclaredMethod(binder.Name);
-
-            lock (myLock)
+            if (method != null)
             {
-                result = method.Invoke(this.o, args);
+                lock (myLock)
+                {
+                    result = method.Invoke(o, args);
+                }
+
+                return true;
             }
-            return true;
-            //return base.TryInvokeMember(binder, args, out result);
+
+            result = null;
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Purpose
Adds support for properties and indexers, in addition to the current support for fields.

Fixes the `NullReferenceException` if an invalid member name is specified.

Also makes the fields of the `ThreadSafe` class read-only, since they should never be modified.

## Approach
The `TryGetMember` and `TrySetMember` methods check for the existence of a property or field with the specified name.

The `TryGetIndex` and `TrySetIndex` methods are overridden to support indexers. **NB:** There doesn't seem to be a clean way to identify the indexer property. The code *should* work for C#, but might fall down if called from VB.

In all cases, if the member is not found, the method returns `false`. This avoids the `NullReferenceException` and throws a more useful binding exception instead.